### PR TITLE
fix: highlight focused notifications as `surface0`

### DIFF
--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -188,8 +188,8 @@ trough {
   margin-top: 10px;
 }
 
-.control-center .notification-group:focus {
-  filter: brightness(85%);
+.control-center .notification-group:focus .notification-background {
+  background-color: $surface0;
 }
 
 scrollbar slider {


### PR DESCRIPTION
Fixes #25 by using `filter: brightness(85%)` to darken the currently focused notification, thus allowing navigation with the up/down arrow keys.

Screenshot below, not overly invasive but different enough to be able to tell where you're going when shifting the focus. (4 is selected)
<img width="524" height="463" alt="image" src="https://github.com/user-attachments/assets/d65cf65c-ff9d-48a7-abbc-ec5e8a4c3992" />
