### PR TITLE
fix: comment out GTK icon size to resolve swaync-client error

### DIFF
--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -240,7 +240,7 @@ scrollbar trough {
 }
 
 .widget-mpris-album-art {
-  -gtk-icon-size: 100px;
+  // -gtk-icon-size: 100px;
   border-radius: 12.6px;
   margin: 0 10px;
 }
@@ -262,9 +262,10 @@ scrollbar trough {
   padding: 2px;
 }
 
-.widget-mpris button image {
-  -gtk-icon-size: 1.8rem;
-}
+// Removed to mitigate error with swaync-client
+// .widget-mpris button image {
+//   -gtk-icon-size: 1.8rem;
+// }
 
 .widget-mpris button:hover {
   background-color: $surface0;


### PR DESCRIPTION
Removed -gtk-icon-size css property that was causing issues when trying to use any catpuccin style.css with swaync-client